### PR TITLE
재체결 시도 로직 구체화 및 전체적인 리팩토링

### DIFF
--- a/src/main/java/cowing/project/cowingmsatrading/CowingMsaTradingApplication.java
+++ b/src/main/java/cowing/project/cowingmsatrading/CowingMsaTradingApplication.java
@@ -2,8 +2,10 @@ package cowing.project.cowingmsatrading;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class CowingMsaTradingApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/cowing/project/cowingmsatrading/global/exception/OrderPendingException.java
+++ b/src/main/java/cowing/project/cowingmsatrading/global/exception/OrderPendingException.java
@@ -1,0 +1,7 @@
+package cowing.project.cowingmsatrading.global.exception;
+
+public class OrderPendingException extends RuntimeException {
+    public OrderPendingException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/cowing/project/cowingmsatrading/trade/controller/TradeController.java
+++ b/src/main/java/cowing/project/cowingmsatrading/trade/controller/TradeController.java
@@ -1,11 +1,11 @@
 package cowing.project.cowingmsatrading.trade.controller;
 
-import cowing.project.cowingmsatrading.global.config.TokenProvider;
 import cowing.project.cowingmsatrading.trade.dto.LimitOrderDto;
 import cowing.project.cowingmsatrading.trade.dto.MarketBuyOrderDto;
 import cowing.project.cowingmsatrading.trade.dto.MarketSellOrderDto;
-import cowing.project.cowingmsatrading.trade.queue.OrderQueue;
-import cowing.project.cowingmsatrading.trade.queue.OrderTask;
+import cowing.project.cowingmsatrading.trade.management.OrderQueue;
+import cowing.project.cowingmsatrading.trade.management.OrderTask;
+import cowing.project.cowingmsatrading.trade.service.OrderService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -22,32 +22,29 @@ import org.springframework.web.bind.annotation.RestController;
 public class TradeController {
 
     private final OrderQueue orderQueue;
-    private final TokenProvider tokenProvider;
+    private final OrderService orderService;
 
     @Operation(summary = "시장가 매수 주문", description = "시장가로 매수 주문을 처리합니다.")
     @ApiResponse(responseCode = "200", description = "주문이 접수되었습니다.")
     @PostMapping("/api/v1/orders/market/buy")
-    public ResponseEntity<String> buy(@RequestBody MarketBuyOrderDto marketBuyOrderDto, @RequestHeader("Authorization") String authorizationHeader) {
-        String username = tokenProvider.getUsername(authorizationHeader.replace("Bearer ", ""));
-        orderQueue.enqueue(new OrderTask(marketBuyOrderDto.toOrder(username), username));
+    public ResponseEntity<String> buy(@RequestBody MarketBuyOrderDto marketBuyOrderDto, @RequestHeader("Authorization") String token) {
+        orderQueue.enqueue(new OrderTask(marketBuyOrderDto.toOrder(orderService.extractUsernameFromToken(token))));
         return ResponseEntity.ok("주문이 접수되었습니다.");
     }
 
     @Operation(summary = "시장가 매도 주문", description = "시장가로 매도 주문을 처리합니다.")
     @ApiResponse(responseCode = "200", description = "주문이 접수되었습니다.")
     @PostMapping("/api/v1/orders/market/sell")
-    public ResponseEntity<String> sell(@RequestBody MarketSellOrderDto marketSellOrderDto, @RequestHeader("Authorization") String authorizationHeader) {
-        String username = tokenProvider.getUsername(authorizationHeader.replace("Bearer ", ""));
-        orderQueue.enqueue(new OrderTask(marketSellOrderDto.toOrder(username), username));
+    public ResponseEntity<String> sell(@RequestBody MarketSellOrderDto marketSellOrderDto, @RequestHeader("Authorization") String token) {
+        orderQueue.enqueue(new OrderTask(marketSellOrderDto.toOrder(orderService.extractUsernameFromToken(token))));
         return ResponseEntity.ok("주문이 접수되었습니다.");
     }
 
     @Operation(summary = "지정가 주문", description = "지정가 매매로 주문을 처리합니다. 매수와 매도 모두 지원합니다.")
     @ApiResponse(responseCode = "200", description = "주문이 접수되었습니다.")
     @PostMapping("/api/v1/orders/limit")
-    public ResponseEntity<String> limit(@RequestBody LimitOrderDto limitOrderDto, @RequestHeader("Authorization") String authorizationHeader) {
-        String username = tokenProvider.getUsername(authorizationHeader.replace("Bearer ", ""));
-        orderQueue.enqueue(new OrderTask(limitOrderDto.toOrder(username), username));
+    public ResponseEntity<String> limit(@RequestBody LimitOrderDto limitOrderDto, @RequestHeader("Authorization") String token) {
+        orderQueue.enqueue(new OrderTask(limitOrderDto.toOrder(orderService.extractUsernameFromToken(token))));
         return ResponseEntity.ok("주문이 접수되었습니다.");
     }
 }

--- a/src/main/java/cowing/project/cowingmsatrading/trade/domain/entity/order/Status.java
+++ b/src/main/java/cowing/project/cowingmsatrading/trade/domain/entity/order/Status.java
@@ -3,5 +3,6 @@ package cowing.project.cowingmsatrading.trade.domain.entity.order;
 public enum Status {
 
     COMPLETED,
-    PENDING
+    PENDING,
+    CANCELLED
 }

--- a/src/main/java/cowing/project/cowingmsatrading/trade/dto/PendingOrderDto.java
+++ b/src/main/java/cowing/project/cowingmsatrading/trade/dto/PendingOrderDto.java
@@ -1,0 +1,8 @@
+package cowing.project.cowingmsatrading.trade.dto;
+
+import cowing.project.cowingmsatrading.trade.domain.entity.order.Order;
+import java.math.BigDecimal;
+
+public record PendingOrderDto(Order order, BigDecimal remaining
+) {
+}

--- a/src/main/java/cowing/project/cowingmsatrading/trade/management/ConcurrentMapProvider.java
+++ b/src/main/java/cowing/project/cowingmsatrading/trade/management/ConcurrentMapProvider.java
@@ -1,0 +1,15 @@
+package cowing.project.cowingmsatrading.trade.management;
+
+import cowing.project.cowingmsatrading.trade.dto.PendingOrderDto;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Configuration
+public class ConcurrentMapProvider {
+
+    @Bean
+    public ConcurrentHashMap<String, PendingOrderDto> getConcurrentMap() {
+        return new ConcurrentHashMap<>();
+    }
+}

--- a/src/main/java/cowing/project/cowingmsatrading/trade/management/OrderQueue.java
+++ b/src/main/java/cowing/project/cowingmsatrading/trade/management/OrderQueue.java
@@ -1,4 +1,4 @@
-package cowing.project.cowingmsatrading.trade.queue;
+package cowing.project.cowingmsatrading.trade.management;
 
 import cowing.project.cowingmsatrading.trade.service.OrderService;
 import jakarta.annotation.PostConstruct;
@@ -29,7 +29,7 @@ public class OrderQueue {
     @PostConstruct
     private void init() {
         executor = Executors.newSingleThreadExecutor();
-        executor.submit(this::process); // 백그라운드에서 큐 처리 시작
+        executor.submit(this::process);
     }
 
     @PreDestroy
@@ -50,8 +50,11 @@ public class OrderQueue {
         try {
             while (!Thread.currentThread().isInterrupted()) {
                 OrderTask task = queue.take();
-                tradeProcessorWrapper.process(task);
-                log.info("{} 를 시작합니다.", task);
+                try {
+                    log.info("{} 처리를 시작합니다.", task);
+                    tradeProcessorWrapper.process(task);
+                } catch (Exception e) {
+                }
             }
         } catch (InterruptedException ignored) {
             Thread.currentThread().interrupt();

--- a/src/main/java/cowing/project/cowingmsatrading/trade/management/OrderTask.java
+++ b/src/main/java/cowing/project/cowingmsatrading/trade/management/OrderTask.java
@@ -1,4 +1,4 @@
-package cowing.project.cowingmsatrading.trade.queue;
+package cowing.project.cowingmsatrading.trade.management;
 
 import cowing.project.cowingmsatrading.trade.domain.entity.order.Order;
 import lombok.AllArgsConstructor;
@@ -11,5 +11,4 @@ import lombok.Getter;
 @Getter
 public class OrderTask {
     private final Order order;
-    private final String username;
 }

--- a/src/main/java/cowing/project/cowingmsatrading/trade/management/TradeProcessorWrapper.java
+++ b/src/main/java/cowing/project/cowingmsatrading/trade/management/TradeProcessorWrapper.java
@@ -1,4 +1,4 @@
-package cowing.project.cowingmsatrading.trade.queue;
+package cowing.project.cowingmsatrading.trade.management;
 
 import cowing.project.cowingmsatrading.trade.service.TradeProcessor;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +14,6 @@ public class TradeProcessorWrapper {
     private final TradeProcessor tradeProcessor;
 
     public void process(OrderTask task) {
-        tradeProcessor.startTradeExecution(task.getOrder(), task.getUsername());
+        tradeProcessor.startTradeExecution(task.getOrder());
     }
 }

--- a/src/main/java/cowing/project/cowingmsatrading/trade/service/OrderService.java
+++ b/src/main/java/cowing/project/cowingmsatrading/trade/service/OrderService.java
@@ -91,7 +91,6 @@ public class OrderService {
 
             return null;
         });
-
     }
 
     @Transactional(readOnly = true)
@@ -112,8 +111,10 @@ public class OrderService {
         return tokenProvider.getUsername(token.replace("Bearer ", ""));
     }
 
-    @Transactional(readOnly = true)
-    public Order findOrderByUsername(String username) {
-        return orderRepository.findOrderByUsername(username);
+    @Transactional
+    public void cancelOrder(Order order) {
+        order.setStatus(Status.CANCELLED);
+        orderRepository.save(order);
     }
+
 }

--- a/src/main/java/cowing/project/cowingmsatrading/trade/service/PendingOrderManager.java
+++ b/src/main/java/cowing/project/cowingmsatrading/trade/service/PendingOrderManager.java
@@ -1,0 +1,64 @@
+package cowing.project.cowingmsatrading.trade.service;
+
+import cowing.project.cowingmsatrading.trade.domain.entity.order.Order;
+import cowing.project.cowingmsatrading.trade.domain.entity.order.OrderPosition;
+import cowing.project.cowingmsatrading.trade.dto.PendingOrderDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.concurrent.ConcurrentMap;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PendingOrderManager {
+
+    private final ConcurrentMap<String, PendingOrderDto> pendingOrders;
+    private final TradeProcessor tradeProcessor;
+    private final OrderService orderService;
+    private static final long TIMEOUT_HOURS = 5;
+
+    @Scheduled(fixedRate = 5000) // 5초마다 미체결 주문 확인
+    private void processPendingOrders() {
+        if (pendingOrders.isEmpty()) {
+            return;
+        }
+
+        for (PendingOrderDto pending : pendingOrders.values()) {
+            Order order = pending.order();
+            if (order.getOrderRequestedAt().isBefore(LocalDateTime.now().minusHours(TIMEOUT_HOURS))) {
+                orderService.cancelOrder(order);
+                pendingOrders.remove(order.getUuid());
+                log.info("주문 시간(5시간) 초과로 취소 처리되었습니다. UUID: {}", order.getUuid());
+                continue;
+            }
+
+            retryTrade(order, pending.remaining());
+        }
+    }
+
+    private void retryTrade(Order order, BigDecimal remaining) {
+        boolean isBuyOrder = order.getOrderPosition() == OrderPosition.BUY;
+        BigDecimal limitPrice = BigDecimal.valueOf(order.getOrderPrice());
+
+        // TradeProcessor의 공통 로직을 재사용하여 체결 시도
+        TradeProcessor.TradeExecutionResult result;
+        try {
+            result = tradeProcessor.executeTradeWithCondition(order, remaining, isBuyOrder, limitPrice);
+        } catch (Exception e) {
+            log.info("체결 재시도 후 체결되지 않았으므로 주문을 대기열에 유지합니다. UUID: {}", e.getMessage());
+            return;
+        }
+
+        if (result.remainingAfterTrade().compareTo(BigDecimal.ZERO) <= 0) {
+            // 체결 후 정산 및 수량 업데이트
+            orderService.processTradeRecordsAndSettlement(order, result.tradeRecords(), result.totalQuantity(), result.totalPrice());
+            pendingOrders.remove(order.getUuid());
+            log.info("미체결 주문이 완전히 체결되어 대기열에서 제거되었습니다. UUID: {}, 체결 수량: {}", order.getUuid(), result.totalQuantity());
+        }
+    }
+}


### PR DESCRIPTION
# 📝작업 내용
- 대기열로 넘어간 매매 요청은 5초마다 재체결을 진행한다. 5시간 이후에도 체결되지 않는다면 취소된다.
- 컨트롤러 부분을 더 가독성 있게 수정하였다.

# #️⃣연관된 이슈
#19 