### PR TITLE
대기열 주문 확인 로그 발생 빈도 감소

### DIFF
--- a/src/main/java/cowing/project/cowingmsatrading/trade/service/PendingOrderManager.java
+++ b/src/main/java/cowing/project/cowingmsatrading/trade/service/PendingOrderManager.java
@@ -41,6 +41,14 @@ public class PendingOrderManager {
         }
     }
 
+    @Scheduled(fixedRate = 600000) // 10분마다 기록
+    private void checkPendingOrders() {
+        if (pendingOrders.isEmpty()) {
+            return;
+        }
+        log.info("대기열에 미체결 주문이 {}건 존재합니다.", pendingOrders.size());
+    }
+
     private void retryTrade(Order order, BigDecimal remaining) {
         boolean isBuyOrder = order.getOrderPosition() == OrderPosition.BUY;
         BigDecimal limitPrice = BigDecimal.valueOf(order.getOrderPrice());
@@ -50,7 +58,6 @@ public class PendingOrderManager {
         try {
             result = tradeProcessor.executeTradeWithCondition(order, remaining, isBuyOrder, limitPrice);
         } catch (Exception e) {
-            log.info("체결 재시도 후 체결되지 않았으므로 주문을 대기열에 유지합니다. UUID: {}", e.getMessage());
             return;
         }
 


### PR DESCRIPTION
# 📝작업 내용
기존 미체결 주문 확인 로그는 5초마다 기록되었다.
```
} catch (Exception e) {
            log.info("체결 재시도 후 체결되지 않았으므로 주문을 대기열에 유지합니다. UUID: {}", e.getMessage());
            return;
        }
```

로그 발생 빈도가 심하게 잦다는 판단이 들어 10분마다 대기열 주문 확인 로그가 기록되도록 하였다.
이번엔 특정 미체결 주문의 UUID를 반환하기 보다 대기열에 있는 미체결 주문 수량을 보여주는 방향으로 선회하였다.


# #️⃣연관된 이슈
#26 