### PR TITLE
미체결 취소 API 구현 및 캐시 전략 수정

### DIFF
--- a/.github/workflows/githubActions.yml
+++ b/.github/workflows/githubActions.yml
@@ -50,13 +50,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: ${{ runner.temp }}/.buildx-cache
-          key: ${{ runner.os }}-docker-${{ hashFiles('Dockerfile', 'build.gradle') }}
-          restore-keys: ${{ runner.os }}-docker-
-
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
@@ -65,14 +58,8 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ steps.image_name.outputs.image_name }}:${{ steps.version.outputs.version }}
             ${{ env.REGISTRY }}/${{ steps.image_name.outputs.image_name }}:latest
-          cache-from: type=local,src=${{ runner.temp }}/.buildx-cache
-          cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-new, mode=max
-
-      # 캐시 누적 방지
-      - name: Move cache
-        run: |
-          rm -rf ${{ runner.temp }}/.buildx-cache
-          mv ${{ runner.temp }}/.buildx-cache-new ${{ runner.temp }}/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       # 디스코드 알람 전송
       - name: Send Discord Notification
@@ -142,14 +129,6 @@ jobs:
               "timestamp": "'"$(date -u +"%Y-%m-%dT%H:%M:%SZ")"'"
             }]
           }'
-
-      - name: Checkout GitOps repository
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ env.GITOPS_REPO }}
-          token: ${{ secrets.GITOPS_TOKEN }}
-          path: gitops
-          ref: prod
 
       - name: Update image tag in kustomization.yaml
         run: |

--- a/src/main/java/cowing/project/cowingmsatrading/trade/controller/HistoryController.java
+++ b/src/main/java/cowing/project/cowingmsatrading/trade/controller/HistoryController.java
@@ -1,6 +1,6 @@
 package cowing.project.cowingmsatrading.trade.controller;
 
-import cowing.project.cowingmsatrading.trade.dto.PendingOrderResponse;
+import cowing.project.cowingmsatrading.trade.dto.PendingOrderData;
 import cowing.project.cowingmsatrading.trade.dto.TradeHistoryResponse;
 import cowing.project.cowingmsatrading.trade.service.HistoryService;
 import cowing.project.cowingmsatrading.trade.service.OrderService;
@@ -52,14 +52,14 @@ public class HistoryController {
             @ApiResponse(responseCode = "200", description = "조회 성공", content = {
                     @Content(
                             mediaType = "application/json",
-                            schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = PendingOrderResponse.class)
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = PendingOrderData.class)
                     )
             }),
             @ApiResponse(responseCode = "400", description = "조회 실패(인증된 사용자가 아니거나 잘못된 요청 형식)")
     })
     @Parameter(name = "Authorization", description = "Bearer 토큰 형식의 인증 헤더", required = true, example = "Bearer your_jwt_token")
     @GetMapping("/orders/pending")
-    public ResponseEntity<List<PendingOrderResponse>> getPendingOrders(@RequestHeader("Authorization") String authorizationHeader) throws AuthenticationException {
+    public ResponseEntity<List<PendingOrderData>> getPendingOrders(@RequestHeader("Authorization") String authorizationHeader) throws AuthenticationException {
         return ResponseEntity.ok(historyService.getPendingOrders(orderService.extractUsernameFromToken(authorizationHeader)));
     }
 }

--- a/src/main/java/cowing/project/cowingmsatrading/trade/controller/OrderController.java
+++ b/src/main/java/cowing/project/cowingmsatrading/trade/controller/OrderController.java
@@ -1,0 +1,29 @@
+package cowing.project.cowingmsatrading.trade.controller;
+
+import cowing.project.cowingmsatrading.trade.dto.PendingOrderData;
+import cowing.project.cowingmsatrading.trade.service.PendingOrderManager;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+
+@Tag(name = "주문 API", description = "매수/매도 주문 및 조회/취소 관련 API")
+@RestController
+@RequestMapping("/api/v1/orders")
+@RequiredArgsConstructor
+public class OrderController {
+    private final PendingOrderManager pendingOrderManager;
+
+    @Operation(summary = "미체결 주문 취소", description = "대기열에 있는 특정 미체결 주문들을 취소합니다.")
+    @ApiResponse(responseCode = "200", description = "취소가 완료되었습니다.")
+    @PostMapping("/pending")
+    public ResponseEntity<String> cancelOrders(@RequestBody List<PendingOrderData> ordersToCancel){
+        pendingOrderManager.cancelPendingOrders(ordersToCancel);
+        return ResponseEntity.ok("취소가 완료되었습니다.");
+    }
+}

--- a/src/main/java/cowing/project/cowingmsatrading/trade/dto/PendingOrderData.java
+++ b/src/main/java/cowing/project/cowingmsatrading/trade/dto/PendingOrderData.java
@@ -11,8 +11,8 @@ import java.math.RoundingMode;
 import java.time.LocalDateTime;
 
 
-@Schema(description = "미체결 주문 응답")
-public record PendingOrderResponse(
+@Schema(description = "미체결 주문 관련 DTO")
+public record PendingOrderData(
         @Schema(description = "주문 UUID", example = "c0e2b0a0-8b7a-4b0e-8b0a-0e2b0a0e2b0a")
         String uuid,
         @Schema(description = "마켓 코드", example = "KRW-BTC")
@@ -32,8 +32,8 @@ public record PendingOrderResponse(
         @Schema(description = "주문 상태", example = "PENDING")
         Status status
 ) {
-    public static PendingOrderResponse of(Order order) {
-        return new PendingOrderResponse(
+    public static PendingOrderData of(Order order) {
+        return new PendingOrderData(
                 order.getUuid(),
                 order.getMarketCode(),
                 order.getOrderType(),

--- a/src/main/java/cowing/project/cowingmsatrading/trade/service/HistoryService.java
+++ b/src/main/java/cowing/project/cowingmsatrading/trade/service/HistoryService.java
@@ -3,7 +3,7 @@ package cowing.project.cowingmsatrading.trade.service;
 import cowing.project.cowingmsatrading.trade.domain.entity.order.Status;
 import cowing.project.cowingmsatrading.trade.domain.repository.OrderRepository;
 import cowing.project.cowingmsatrading.trade.domain.repository.TradeRepository;
-import cowing.project.cowingmsatrading.trade.dto.PendingOrderResponse;
+import cowing.project.cowingmsatrading.trade.dto.PendingOrderData;
 import cowing.project.cowingmsatrading.trade.dto.TradeHistoryResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,10 +30,10 @@ public class HistoryService {
     }
 
     @Transactional(readOnly = true)
-    public List<PendingOrderResponse> getPendingOrders(String username) throws AuthenticationException {
+    public List<PendingOrderData> getPendingOrders(String username) throws AuthenticationException {
             validateUsername(username);
             return orderRepository.findAllByUsernameAndStatus(username, Status.PENDING).stream()
-                    .map(PendingOrderResponse::of)
+                    .map(PendingOrderData::of)
                     .toList();
     }
 


### PR DESCRIPTION
# 📝작업 내용
미체결 중인 주문 내역을 일괄 취소는 api를 구현하였다.
Swagger 일부 DTO의 설명을 수정하였다.
마지막으로, 기존 로컬 캐시가 GHA보다 저장용량의 한계로 원하는 결과가 나오지 않아. GHA로 수정하였다.

# #️⃣연관된 이슈
#34 