### PR TITLE
거래 엔진 리팩토링

### DIFF
--- a/src/main/java/cowing/project/cowingmsatrading/trade/controller/OrderController.java
+++ b/src/main/java/cowing/project/cowingmsatrading/trade/controller/OrderController.java
@@ -1,7 +1,7 @@
 package cowing.project.cowingmsatrading.trade.controller;
 
 import cowing.project.cowingmsatrading.trade.dto.PendingOrderData;
-import cowing.project.cowingmsatrading.trade.service.PendingOrderManager;
+import cowing.project.cowingmsatrading.trade.service.processor.PendingOrderManager;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/cowing/project/cowingmsatrading/trade/controller/TradeController.java
+++ b/src/main/java/cowing/project/cowingmsatrading/trade/controller/TradeController.java
@@ -3,7 +3,7 @@ package cowing.project.cowingmsatrading.trade.controller;
 import cowing.project.cowingmsatrading.trade.dto.LimitOrderDto;
 import cowing.project.cowingmsatrading.trade.dto.MarketBuyOrderDto;
 import cowing.project.cowingmsatrading.trade.dto.MarketSellOrderDto;
-import cowing.project.cowingmsatrading.trade.service.TradeRequestPublisher;
+import cowing.project.cowingmsatrading.trade.service.processor.TradeRequestPublisher;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/cowing/project/cowingmsatrading/trade/dto/TradeCalculationResult.java
+++ b/src/main/java/cowing/project/cowingmsatrading/trade/dto/TradeCalculationResult.java
@@ -1,0 +1,6 @@
+package cowing.project.cowingmsatrading.trade.dto;
+
+import java.math.BigDecimal;
+
+public record TradeCalculationResult(BigDecimal tradeQuantity, BigDecimal tradePrice, BigDecimal remainingAfterTrade) {
+}

--- a/src/main/java/cowing/project/cowingmsatrading/trade/dto/TradeExecutionResult.java
+++ b/src/main/java/cowing/project/cowingmsatrading/trade/dto/TradeExecutionResult.java
@@ -1,0 +1,9 @@
+package cowing.project.cowingmsatrading.trade.dto;
+
+import cowing.project.cowingmsatrading.trade.domain.entity.order.Trade;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record TradeExecutionResult(List<Trade> tradeRecords, BigDecimal totalQuantity, BigDecimal totalPrice, BigDecimal remainingAfterTrade) {
+}

--- a/src/main/java/cowing/project/cowingmsatrading/trade/service/OrderService.java
+++ b/src/main/java/cowing/project/cowingmsatrading/trade/service/OrderService.java
@@ -35,7 +35,7 @@ public class OrderService {
         orderRepository.save(order);
     }
 
-    protected void processTradeRecordsAndSettlement(Order order, List<Trade> tradeRecords, BigDecimal totalQuantity, BigDecimal totalPrice) {
+    public void processTradeRecordsAndSettlement(Order order, List<Trade> tradeRecords, BigDecimal totalQuantity, BigDecimal totalPrice) {
         transactionTemplate.execute(status -> {
             // 체결 내역 저장
             tradeRepository.saveAll(tradeRecords);
@@ -96,31 +96,7 @@ public class OrderService {
         });
     }
 
-    @Transactional(readOnly = true)
-    public boolean checkUserAssets(String username, Long totalPrice) {
-        return userRepository.findByUsername(username)
-                .map(user -> user.getUHoldings() >= totalPrice)
-                .orElse(false);
-    }
-
-    @Transactional(readOnly = true)
-    public boolean checkPortfolio(String username, String marketCode, BigDecimal totalQuantity) {
-        return portfolioRepository.findByUsernameAndMarketCode(username, marketCode)
-                .map(portfolio -> portfolio.getQuantity().compareTo(totalQuantity) >= 0)
-                .orElse(false);
-    }
-
-    public String extractUsernameFromToken(String token) {
-        return tokenProvider.getUsername(token.replace("Bearer ", ""));
-    }
-
-    @Transactional
-    public void cancelOrder(Order order) {
-        order.setStatus(Status.CANCELLED);
-        orderRepository.save(order);
-    }
-
-    protected void validateOrderPreconditions(String username, Order order) throws IllegalArgumentException {
+    public void validateOrderPreconditions(String username, Order order) throws IllegalArgumentException {
         transactionTemplate.execute(status -> {
             userRepository.findByUsername(username)
                     .ifPresentOrElse(
@@ -151,5 +127,16 @@ public class OrderService {
             return null;
         });
     }
+
+    public String extractUsernameFromToken(String token) {
+        return tokenProvider.getUsername(token.replace("Bearer ", ""));
+    }
+
+    @Transactional
+    public void cancelOrder(Order order) {
+        order.setStatus(Status.CANCELLED);
+        orderRepository.save(order);
+    }
+
 
 }

--- a/src/main/java/cowing/project/cowingmsatrading/trade/service/processor/PendingOrderManager.java
+++ b/src/main/java/cowing/project/cowingmsatrading/trade/service/processor/PendingOrderManager.java
@@ -4,6 +4,7 @@ import cowing.project.cowingmsatrading.trade.domain.entity.order.Order;
 import cowing.project.cowingmsatrading.trade.domain.entity.order.OrderPosition;
 import cowing.project.cowingmsatrading.trade.dto.PendingOrderData;
 import cowing.project.cowingmsatrading.trade.dto.PendingOrderDto;
+import cowing.project.cowingmsatrading.trade.dto.TradeExecutionResult;
 import cowing.project.cowingmsatrading.trade.service.OrderService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -58,7 +59,7 @@ public class PendingOrderManager {
         BigDecimal limitPrice = BigDecimal.valueOf(order.getOrderPrice());
 
         // TradeProcessor의 공통 로직을 재사용하여 체결 시도
-        TradeProcessor.TradeExecutionResult result;
+        TradeExecutionResult result;
         try {
             result = tradeProcessor.executeTradeWithCondition(order, remaining, isBuyOrder, limitPrice);
         } catch (Exception e) {

--- a/src/main/java/cowing/project/cowingmsatrading/trade/service/processor/PendingOrderManager.java
+++ b/src/main/java/cowing/project/cowingmsatrading/trade/service/processor/PendingOrderManager.java
@@ -1,9 +1,10 @@
-package cowing.project.cowingmsatrading.trade.service;
+package cowing.project.cowingmsatrading.trade.service.processor;
 
 import cowing.project.cowingmsatrading.trade.domain.entity.order.Order;
 import cowing.project.cowingmsatrading.trade.domain.entity.order.OrderPosition;
 import cowing.project.cowingmsatrading.trade.dto.PendingOrderData;
 import cowing.project.cowingmsatrading.trade.dto.PendingOrderDto;
+import cowing.project.cowingmsatrading.trade.service.OrderService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;

--- a/src/main/java/cowing/project/cowingmsatrading/trade/service/processor/TradeProcessor.java
+++ b/src/main/java/cowing/project/cowingmsatrading/trade/service/processor/TradeProcessor.java
@@ -1,4 +1,4 @@
-package cowing.project.cowingmsatrading.trade.service;
+package cowing.project.cowingmsatrading.trade.service.processor;
 
 import cowing.project.cowingmsatrading.global.exception.OrderPendingException;
 import cowing.project.cowingmsatrading.orderbook.RealTimeOrderbook;
@@ -7,6 +7,7 @@ import cowing.project.cowingmsatrading.trade.domain.entity.order.Order;
 import cowing.project.cowingmsatrading.trade.domain.entity.order.OrderPosition;
 import cowing.project.cowingmsatrading.trade.domain.entity.order.Trade;
 import cowing.project.cowingmsatrading.trade.dto.PendingOrderDto;
+import cowing.project.cowingmsatrading.trade.service.OrderService;
 import io.awspring.cloud.sqs.annotation.SqsListener;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,33 +30,14 @@ public class TradeProcessor {
 
     private static final int MAX_ATTEMPTS = 5;
 
-    @SqsListener(queueNames = "sample-queue.fifo")
+    @SqsListener(queueNames = "${QUEUE_NAME}")
     public void startTradeExecution(Order orderForExecution) {
-            // 주문이 유효한지 확인한다. 매수 주문일 때, 사용자의 보유 금액이 충분한지 확인하고, 매도 주문일 때, 사용자의 보유 수량이 충분한지 확인한다.
-            validateCurrentOrder(orderForExecution);
 
             // 요청 타입에 따라 각 메서드로 분기한다
             switch (orderForExecution.getOrderType()) {
                 case MARKET -> executeMarketOrder(orderForExecution);
                 case LIMIT -> executeLimitOrder(orderForExecution);
             }
-    }
-
-    private void validateCurrentOrder(Order orderForExecution) {
-        switch (orderForExecution.getOrderPosition()) {
-            case BUY -> {
-                if (!orderService.checkUserAssets(orderForExecution.getUsername(), orderForExecution.getTotalPrice())) {
-                    log.error("사용자의 자산이 부족합니다. 주문을 처리할 수 없습니다.");
-                    throw new IllegalStateException("사용자의 자산이 부족합니다.");
-                }
-            }
-            case SELL -> {
-                if (!orderService.checkPortfolio(orderForExecution.getUsername(), orderForExecution.getMarketCode(), orderForExecution.getTotalQuantity())) {
-                    log.error("사용자의 포트폴리오에 충분한 수량이 없습니다. 주문을 처리할 수 없습니다.");
-                    throw new IllegalStateException("사용자의 포트폴리오에 충분한 수량이 없습니다.");
-                }
-            }
-        }
     }
 
     // 시장가 매매 주문 처리

--- a/src/main/java/cowing/project/cowingmsatrading/trade/service/processor/TradeProcessor.java
+++ b/src/main/java/cowing/project/cowingmsatrading/trade/service/processor/TradeProcessor.java
@@ -7,6 +7,8 @@ import cowing.project.cowingmsatrading.trade.domain.entity.order.Order;
 import cowing.project.cowingmsatrading.trade.domain.entity.order.OrderPosition;
 import cowing.project.cowingmsatrading.trade.domain.entity.order.Trade;
 import cowing.project.cowingmsatrading.trade.dto.PendingOrderDto;
+import cowing.project.cowingmsatrading.trade.dto.TradeCalculationResult;
+import cowing.project.cowingmsatrading.trade.dto.TradeExecutionResult;
 import cowing.project.cowingmsatrading.trade.service.OrderService;
 import io.awspring.cloud.sqs.annotation.SqsListener;
 import lombok.RequiredArgsConstructor;
@@ -202,11 +204,4 @@ public class TradeProcessor {
         return remaining.compareTo(BigDecimal.ZERO) == 0;
     }
 
-    // 거래 계산 결과를 담는 레코드
-    public record TradeCalculationResult(BigDecimal tradeQuantity, BigDecimal tradePrice, BigDecimal remainingAfterTrade) {
-    }
-
-    // 거래 실행 결과
-    public record TradeExecutionResult(List<Trade> tradeRecords, BigDecimal totalQuantity, BigDecimal totalPrice, BigDecimal remainingAfterTrade) {
-    }
 }


### PR DESCRIPTION
# 📝작업 내용
거래 엔진 리팩토링을 진행하였다.
- DB에 직접 접근할 권한이 있는 service 클래스를 제외한 나머지는 processor 디렉토리로 옮겨서 역할을 확실히 분리하였다.
- 모든 매매 요청은 sqs로 보내지기 전 유효성 검사를 진행한다. 따라서 sqs에서 dequeue 되고 나서도 재검사를 진행할 필요는 없기에 해당 과정을 로직에서 제하였다.
```
이 부분에서 체결 속도가 개선될 것.
```
- 불필요한 메서드를 삭제하였다.
- queue name을 애플리케이션에 명시하지 않고 환경 변수로 주입되도록 했다.

# #️⃣연관된 이슈
#38 